### PR TITLE
Add checks for streamlit app

### DIFF
--- a/.github/workflows/check_experiments.yml
+++ b/.github/workflows/check_experiments.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: Check Fourier Training
         run: cd experiments/fourier_training && make train_dry_run
+
+      - name: Check Fourier Training Streamlit
+        run: cd experiments/fourier_training && make check_streamlit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,4 +32,4 @@ jobs:
         run: uv run pyright
 
       - name: Run tests
-        run: uv run pytest --cov-report term --cov src
+        run: uv run pytest --cov-report term --cov src tests/

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ type-check:
 	uv run pyright
 
 test:
-	uv run pytest
+	uv run pytest tests/
 
 test-with-coverage:
-	uv run pytest --cov-report term --cov src
+	uv run pytest --cov-report term --cov src tests/

--- a/experiments/fourier_training/Makefile
+++ b/experiments/fourier_training/Makefile
@@ -22,3 +22,6 @@ bulk_train:
 
 streamlit:
 	uv run streamlit run streamlit_vis.py
+
+check_streamlit:
+	uv run python test_streamlit.py

--- a/experiments/fourier_training/test_streamlit.py
+++ b/experiments/fourier_training/test_streamlit.py
@@ -1,0 +1,5 @@
+from streamlit.testing.v1 import AppTest
+
+at = AppTest.from_file("streamlit_vis.py")
+at.run()
+assert not at.exception


### PR DESCRIPTION
- Adds a file `experiments/fourier_training/test_streamlit.py` which loads the fourier_training streamlit app and verifies that no exceptions are thrown on the first run
- Adds a target `check_streamlit` to the `experiments/fourier_training` Makefile that runs `test_streamlit.py`
- Adds the aforementioned target to the `check_experiments` Github Actions workflow

Closes #29 